### PR TITLE
skip property name validation

### DIFF
--- a/bridgeql/django/models.py
+++ b/bridgeql/django/models.py
@@ -108,6 +108,7 @@ class ModelConfig(object):
     def validate_fields(self, query_fields):
         # combination of all fields used in query
         for q_field in query_fields:
+            print(q_field)
             parent = self
             for field in q_field.split('__'):
                 field_obj = Field(parent, field)
@@ -123,12 +124,11 @@ class ModelConfig(object):
                     else:
                         break
                 except FieldDoesNotExist:
-                    has_prop = hasattr(parent.model, field_obj.name)
-                    if not has_prop:
-                        raise InvalidModelFieldName(
-                            'Invalid field name %s for model %s.' %
-                            (field_obj.name, parent.full_model_name)
-                        )
+                    if hasattr(parent.model, field_obj.name):
+                        prop_obj = Field(parent, field_obj.name)
+                        if prop_obj.is_restricted:
+                            raise ForbiddenModelOrField('%s is restricted for model %s' %
+                                                        (prop_obj.name, parent.full_model_name))
         return True
 
 

--- a/bridgeql/django/settings.py
+++ b/bridgeql/django/settings.py
@@ -2,8 +2,6 @@
 # Copyright © 2023 VMware, Inc.  All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
-from collections import Iterable
-
 from django.apps import apps
 from django.conf import settings
 

--- a/tests/server/machine/tests/test_api_reader.py
+++ b/tests/server/machine/tests/test_api_reader.py
@@ -289,6 +289,18 @@ class TestAPIReader(TestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertFalse(resp.json()['success'])
 
+    def test_model_isnull(self):
+        self.params = {
+            'app_name': 'machine',
+            'model_name': 'Machine',
+            'filter': {
+                'os__isnull': True,
+            },
+            'fields': ['name', 'arch'],
+        }
+        resp = self.client.get(self.url, {'payload': json.dumps(self.params)})
+        self.assertEqual(resp.status_code, 200)
+
     @override_settings(BRIDGEQL_AUTHENTICATION_DECORATOR='server.auth.localtest')
     def test_custom_auth_decorator(self):
         self.params = {


### PR DESCRIPTION
Currently we validate property name for a model by checking if the model has the attribute with name that of property. This is causing some issues as there might be a filter such as fkey_isnull, now since isnull is not a valid property name this will cause an InvalidModelFieldName error. Hence we decided to skip this validation and only check for restrictions and let django handle invalid property/fieldname

Added test cases