### PR TITLE
Add pipeline to lint, test and build brideql on every push

### DIFF
--- a/.github/workflows/lint-test-and-build-pipeline.yml
+++ b/.github/workflows/lint-test-and-build-pipeline.yml
@@ -1,0 +1,49 @@
+name : brigdeql-lint-test-and-build
+
+# Event type, here this pipe will be triggered post every push 
+on: push
+
+jobs:
+  test-build:
+    name: test and build bridgeql
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['2.7', '3.7', '3.8', '3.9']
+    steps:
+      # Job to checkout the latest code of the respective branch
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # Job to update pip
+      - name: Updating Pip
+        run: python -m pip install --upgrade pip
+
+      # Job to check code with pep8 compliance (For python 2.7)
+      - name: Checking Code with PEP8 compliance
+        run: pip install autopep8==0.8 && autopep8 --in-place -v -r .
+        if: ${{ matrix.python-version  == '2.7' }}
+
+      # Job to check code with pep8 compliance (For python > 3)
+      - name: Checking Code with PEP8 compliance
+        run: pip install autopep8 && autopep8 --in-place -v --exclude=venv,.tox -r .
+        if: ${{ matrix.python-version != '2.7' }} 
+        
+      # Job to run unit test cases [py2.7], (handled via tox)
+      - name: Running tox (For python 2.7)
+        run: pip install tox && tox
+        continue-on-error: true
+        if: ${{ matrix.python-version == '2.7' }}
+        
+       # Job to run unit test cases[py3+], (handled via tox)
+      - name: Running tox (For python 3+)
+        run: pip install tox && tox
+        if: ${{ matrix.python-version != '2.7' }}
+
+
+      # Job to build the brideql backage
+      - name: Build bridgeql package
+        run: python -m pip install --upgrade build && python -m build


### PR DESCRIPTION
## Reason for this MR
The MR request adds a pipe that will do the following steps:
0. Generate a matrix of different python versions
1. Checkout to the latest code
2. Update the package pip
3. Lint the code and view the difference (PEP8)
4. Run test cases via tox
5. Build the package

## Issues
https://github.com/vmware/bridgeql/issues/5