### PR TITLE
Schema page functionality

### DIFF
--- a/bridgeql/django/models.py
+++ b/bridgeql/django/models.py
@@ -66,6 +66,15 @@ class Field(object):
         return (self.name in self.model_config.restricted_fields)
 
 
+class FieldAttributes(object):
+
+    def __init__(self, name, is_null, field_type, help_text):
+        self.field_name = name
+        self.is_null = is_null
+        self.field_type = field_type
+        self.help_text = help_text
+
+
 class ModelConfig(object):
     def __init__(self, app_name, model_name):
         self.app_name = app_name
@@ -73,9 +82,26 @@ class ModelConfig(object):
         self.restricted_fields = self._get_restricted_fields()
         self.model = self._get_model()  # restricted_fields list to set
         self.fields = self._get_fields()
+        self.fields_attrs = {}
+
+    def get_fields_attrs(self):
+        _restricted_fields = self._get_restricted_fields()
+        for field in self.model._meta.local_fields:
+            if field.name not in _restricted_fields:
+                self.fields_attrs[field.name] = FieldAttributes(
+                    field.name, field.null, field.get_internal_type(), field.help_text)
+
+        for _property in self.get_properties():
+            if _property not in _restricted_fields:
+                self.fields_attrs[_property] = FieldAttributes(
+                    _property, None, "ReadOnly Propery", None)
+        return self.fields_attrs
 
     def _get_fields(self):
-        return set([f.name for f in self.model._meta.get_fields()])
+        return set([f.name for f in self.model._meta.local_fields])
+
+    def get_properties(self):
+        return set(self.model._meta._property_names) - {'pk'}
 
     def _get_restricted_fields(self):
         # get from settings

--- a/bridgeql/django/schema.py
+++ b/bridgeql/django/schema.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2023 VMware, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+from collections import defaultdict
+
+from django.apps import apps
+
+from bridgeql.django.settings import BridgeQLSettings
+
+
+class BridgeqlModelFields(object):
+
+    @classmethod
+    def get_all_app_models(cls):
+        _apps = apps.get_app_configs()
+        _all_apps = [{_app.name: [_model.__name__ for _model in _app.get_models()]}
+                     for _app in _apps]
+        return _all_apps
+
+    @classmethod
+    def get_local_apps_models(cls):
+        _local_apps = BridgeQLSettings.get_local_apps()
+        _all_apps = cls.get_all_app_models()
+        _local_apps_models = defaultdict(list)
+        for _app in _local_apps:
+            for each in _all_apps:
+                if each.get(_app):
+                    _local_apps_models[_app] = each.get(_app)
+        return _local_apps_models

--- a/bridgeql/django/settings.py
+++ b/bridgeql/django/settings.py
@@ -84,7 +84,8 @@ class BridgeQLSettings:
             self._validate_auth_decorator()
         )
 
-    def get_local_apps(self):
+    @classmethod
+    def get_local_apps(cls):
         local_apps = []
         project_root = os.path.abspath(settings.BASE_DIR)
         for app in apps.get_app_configs():

--- a/bridgeql/django/urls.py
+++ b/bridgeql/django/urls.py
@@ -9,11 +9,12 @@ except ImportError:
 
 from bridgeql.django.bridge import read_django_model
 from bridgeql.django.settings import bridgeql_settings
-from bridgeql.django.views import index
+from bridgeql.django.views import index, generate_bridgeql_schema
 
 bridgeql_settings.validate()
 
 urlpatterns = [
-    path('^dj_read/', read_django_model, name='bridgeql_django_read'),
+    path('dj_read/', read_django_model, name='bridgeql_django_read'),
+    path('schema/', generate_bridgeql_schema, name='generate_bridgeql_schema'),
     path('', index, name='bridgeql_django_index'),
 ]

--- a/bridgeql/django/views.py
+++ b/bridgeql/django/views.py
@@ -2,8 +2,18 @@
 # Copyright © 2023 VMware, Inc.  All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+
+from collections import defaultdict
+
 from django.shortcuts import render
+from django.views.decorators.http import require_GET
+from django.contrib.admin.views.decorators import staff_member_required
+
+
 from bridgeql import __copyright__, __license__, __title__, __version__
+from bridgeql.django.auth import auth_decorator
+from bridgeql.django.schema import BridgeqlModelFields
+from bridgeql.django.models import ModelConfig
 
 
 def index(request):
@@ -15,3 +25,17 @@ def index(request):
                       "version": __version__,
                   }
                   )
+
+
+@staff_member_required
+@require_GET
+def generate_bridgeql_schema(request):
+    model_info = defaultdict(dict)
+    local_apps_models = BridgeqlModelFields.get_local_apps_models()
+    for app, models in local_apps_models.items():
+        model_info[app] = {}
+        for model in models:
+            _model_config = ModelConfig(app, model)
+            _model_name = _model_config.full_model_name
+            model_info[app][_model_name] = _model_config.get_fields_attrs()
+    return render(request, "bridgeql/schema.html", {"model_info": dict(model_info)})

--- a/bridgeql/templates/bridgeql/index.html
+++ b/bridgeql/templates/bridgeql/index.html
@@ -18,5 +18,7 @@
     <p>Lincese info :: {{license}}</p>
     <p>Copyright info :: {{copyright}}</p>
     </p>
+    <br/>
+    References for implementation <a href="{% url 'generate_bridgeql_schema' %}"> BridgeQL Schema </a>
   </body>
 </html>

--- a/bridgeql/templates/bridgeql/schema.html
+++ b/bridgeql/templates/bridgeql/schema.html
@@ -1,0 +1,105 @@
+<!--
+# -*- coding: utf-8 -*-
+# Copyright © 2023 VMware, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+-->
+
+<html>
+  <head>
+  <style>
+    table, th, td {
+    border: 1px solid white;
+    }
+    th, td {
+     background-color: #96D4D4;
+    }
+</style>
+    <title>
+    BridgqQL - App Model Schema
+    </title>
+  </head>
+  <body>
+    <h1>
+    </h1>
+    <table style="width:75%"> 
+    <tr>
+        <th> App Name </th>
+        <th> Model Name and fields </th>
+    </tr>
+
+    {% for app_name, model_info in model_info.items %}
+    <tr>
+        <td> <b> {{ app_name }} </b> </td>
+
+        <td>
+        <table style="width:100%">
+        {% for model, fields in model_info.items %}
+            <tr> 
+                <td> <b> {{ model }} </b> </td> 
+
+                <td>
+                    <table style="width:100%">
+                        {% for field , f_attrs in fields.items %}
+                            {% if forloop.first %}
+                                <tr> 
+                                <th> Name </th>
+                                <th> Mandatory </th>
+                                <th> Field type </th>
+                                <th> Help text</th>
+                                </tr>
+                            {% endif %}
+                                <tr> 
+                                <td> {{ f_attrs.field_name }} </td>
+                                <td> {% if f_attrs.is_null %} No {% else %} Yes {% endif %} </td>
+                                <td> {{ f_attrs.field_type }} </td>
+                                <td> {{ f_attrs.help_text }} </td>
+                                <tr> 
+                        {% endfor %}
+                    </table>
+               </td>
+
+            </tr>
+        {% endfor %}
+        </table>
+        </td>
+
+    </tr>
+    {% endfor %}
+
+
+
+
+    {% comment %}
+
+
+    {% for app_name, model_info in model_info.items %}
+    {{ app_name }}
+
+    <tr> 
+    <td> {{ app_name }} </td> 
+    </tr>
+
+    <!-- Models in different rows -->
+
+    {% for model, fields in model_info.items %}
+    <tr> 
+
+    <td> {{ model }} </td> 
+    <td> {{  fields }} </td> 
+
+    </tr>
+    {% endfor %}
+
+
+
+    </tr>
+    {% endfor %}
+
+
+
+    {% endcomment %}
+    </table>
+
+    </p>
+  </body>
+</html>

--- a/tests/server/machine/tests/test_views.py
+++ b/tests/server/machine/tests/test_views.py
@@ -2,6 +2,7 @@
 # Copyright © 2023 VMware, Inc.  All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+from django.contrib.auth.models import User
 from django.urls import reverse
 from django.test import TestCase
 from django.test.client import Client
@@ -10,9 +11,28 @@ from django.test.client import Client
 class TestViews(TestCase):
 
     def setUp(self):
-        self.url = reverse('bridgeql_django_index')
         self.client = Client()
 
     def test_page_index(self):
-        resp = self.client.get(self.url)
+        _url = reverse('bridgeql_django_index')
+        resp = self.client.get(_url)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_page_schema_should_fail(self):
+        testuser_without_staff = User.objects.create(username='testuser_without_staff')
+        testuser_without_staff.set_password('password')
+        testuser_without_staff.save()
+        _url = reverse('generate_bridgeql_schema')
+        self.client.login(username="testuser_without_staff", password="password")
+        resp = self.client.get(_url)
+        self.assertEqual(resp.status_code, 302)
+
+    def test_page_schema_should_pass(self):
+        testuser_with_staff = User.objects.create(username='testuser_with_staff')
+        testuser_with_staff.set_password('password')
+        testuser_with_staff.is_staff = True
+        testuser_with_staff.save()
+        _url = reverse('generate_bridgeql_schema')
+        self.client.login(username="testuser_with_staff", password="password")
+        resp = self.client.get(_url)
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
Implemented schema page functionality to show apps, models and fields available in the application. This page is only accessible by user with staff access and it will act as documentation for making BridgeQL API requests.