### PR TITLE
perform limit and offset operation before evaluating queryset

### DIFF
--- a/bridgeql/django/views.py
+++ b/bridgeql/django/views.py
@@ -11,7 +11,6 @@ from django.contrib.admin.views.decorators import staff_member_required
 
 
 from bridgeql import __copyright__, __license__, __title__, __version__
-from bridgeql.django.auth import auth_decorator
 from bridgeql.django.schema import BridgeqlModelFields
 from bridgeql.django.models import ModelConfig
 

--- a/tests/server/machine/tests/test_api_reader.py
+++ b/tests/server/machine/tests/test_api_reader.py
@@ -311,7 +311,7 @@ class TestAPIReader(TestCase):
             'filter': {
                 'os__isnull': True,
             },
-            'fields': ['name', 'arch'],
+            'fields': ['name', 'os__arch'],
         }
         resp = self.client.get(self.url, {'payload': json.dumps(self.params)})
         self.assertEqual(resp.status_code, 200)
@@ -323,7 +323,7 @@ class TestAPIReader(TestCase):
             'filter': {
                 'os__isnull': True,
             },
-            'fields': ['name', 'arch'],
+            'fields': ['name', 'os__arch'],
             'count': 'yes_invalid'
         }
         resp = self.client.get(self.url, {'payload': json.dumps(self.params)})


### PR DESCRIPTION
Incase of foreign key reference, we evaluate the complete queryset by iterating through all of the rows first and then perform slicing operation for limit and offset. Hence in cases if limit is present and total number of rows in a table is very large `__add_fields` will iterate through all the rows, which is very inefficient. So this change limits the query first before evaluating the query set. This will make queries containing foreign key faster if limit is present

Additional changes: remove unused imports