### PR TITLE
Implemented settings BRIDGEQL_ALLOWED_APPS

### DIFF
--- a/bridgeql/django/helpers.py
+++ b/bridgeql/django/helpers.py
@@ -13,6 +13,7 @@ from django.http import HttpResponse
 
 
 from bridgeql.django.exceptions import InvalidBridgeQLSettings
+from bridgeql.django.settings import bridgeql_settings
 
 class JSONEncoder(json.JSONEncoder):
     '''
@@ -44,18 +45,14 @@ class JSONResponse(HttpResponse):
 
 
 def get_local_apps():
+    _local_apps = []
     if hasattr(settings, 'BASE_DIR'):
         project_root = os.path.abspath(settings.BASE_DIR)
     elif hasattr(settings, 'SITE_ROOT'):
         project_root = os.path.abspath(settings.SITE_ROOT)
     else:
-        project_root = None
+        return _local_apps
 
-    if not project_root:
-        raise InvalidBridgeQLSettings(
-                'Could not find BASE_DIR and SITE_ROOT \
-                BRIDGEQL_ALLOWED_APPS needs to be initilised in settings')
-    _local_apps = []
     for app in apps.get_app_configs():
         if os.path.dirname(app.path) == project_root:
             _local_apps.append(app.label)
@@ -63,8 +60,4 @@ def get_local_apps():
 
 
 def get_allowed_apps():
-    if hasattr(settings, 'BRIDGEQL_ALLOWED_APPS'):
-        return settings.BRIDGEQL_ALLOWED_APPS or get_local_apps()
-    raise InvalidBridgeQLSettings(
-            'BRIDGEQL_ALLOWED_APPS needs to be initilised in settings')
-
+    return bridgeql_settings.BRIDGEQL_ALLOWED_APPS or get_local_apps()

--- a/bridgeql/django/helpers.py
+++ b/bridgeql/django/helpers.py
@@ -2,12 +2,17 @@
 # Copyright © 2023 VMware, Inc.  All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause
 
+import os
 from datetime import datetime
 import json
 
-from django.http import HttpResponse
+from django.apps import apps
+from django.conf import settings
 from django.db.models.query import QuerySet
+from django.http import HttpResponse
 
+
+from bridgeql.django.exceptions import InvalidBridgeQLSettings
 
 class JSONEncoder(json.JSONEncoder):
     '''
@@ -36,3 +41,30 @@ class JSONResponse(HttpResponse):
         else:
             data = json.dumps(content, indent=3, cls=encoder)
         HttpResponse.__init__(self, data, content_type, status)
+
+
+def get_local_apps():
+    if hasattr(settings, 'BASE_DIR'):
+        project_root = os.path.abspath(settings.BASE_DIR)
+    elif hasattr(settings, 'SITE_ROOT'):
+        project_root = os.path.abspath(settings.SITE_ROOT)
+    else:
+        project_root = None
+
+    if not project_root:
+        raise InvalidBridgeQLSettings(
+                'Could not find BASE_DIR and SITE_ROOT \
+                BRIDGEQL_ALLOWED_APPS needs to be initilised in settings')
+    _local_apps = []
+    for app in apps.get_app_configs():
+        if os.path.dirname(app.path) == project_root:
+            _local_apps.append(app.label)
+    return _local_apps
+
+
+def get_allowed_apps():
+    if hasattr(settings, 'BRIDGEQL_ALLOWED_APPS'):
+        return settings.BRIDGEQL_ALLOWED_APPS or get_local_apps()
+    raise InvalidBridgeQLSettings(
+            'BRIDGEQL_ALLOWED_APPS needs to be initilised in settings')
+

--- a/bridgeql/django/models.py
+++ b/bridgeql/django/models.py
@@ -94,7 +94,7 @@ class ModelConfig(object):
         for _property in self.get_properties():
             if _property not in _restricted_fields:
                 self.fields_attrs[_property] = FieldAttributes(
-                    _property, None, "ReadOnly Propery", None)
+                    _property, None, "ReadOnly Property", None)
         return self.fields_attrs
 
     def _get_fields(self):

--- a/bridgeql/django/schema.py
+++ b/bridgeql/django/schema.py
@@ -7,6 +7,8 @@ from collections import defaultdict
 from django.apps import apps
 
 from bridgeql.django.settings import BridgeQLSettings
+from bridgeql.django.helpers import get_allowed_apps
+from bridgeql.django.exceptions import InvalidBridgeQLSettings
 
 
 class BridgeqlModelFields(object):
@@ -20,7 +22,10 @@ class BridgeqlModelFields(object):
 
     @classmethod
     def get_local_apps_models(cls):
-        _local_apps = BridgeQLSettings.get_local_apps()
+        try:
+            _local_apps = get_allowed_apps()
+        except InvalidBridgeQLSettings:
+            raise
         _all_apps = cls.get_all_app_models()
         _local_apps_models = defaultdict(list)
         for _app in _local_apps:

--- a/bridgeql/django/schema.py
+++ b/bridgeql/django/schema.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 
 from django.apps import apps
 
-from bridgeql.django.settings import BridgeQLSettings
 from bridgeql.django.helpers import get_allowed_apps
 from bridgeql.django.exceptions import InvalidBridgeQLSettings
 

--- a/bridgeql/django/settings.py
+++ b/bridgeql/django/settings.py
@@ -7,13 +7,12 @@ from django.conf import settings
 
 from bridgeql.django.exceptions import InvalidBridgeQLSettings, InvalidAppOrModelName, InvalidModelFieldName
 from bridgeql.utils import load_function
-from .helpers import get_allowed_apps
-import os
 
 
 DEFAULTS = {
     'BRIDGEQL_RESTRICTED_MODELS': {},
     'BRIDGEQL_AUTHENTICATION_DECORATOR': '',
+    'BRIDGEQL_ALLOWED_APPS': []
 }
 
 
@@ -65,18 +64,6 @@ class BridgeQLSettings:
                 raise InvalidModelFieldName(
                     'Invalid one or more fields %s in settings.BRIDGEQL_RESTRICTED_MODELS.'
                     % restricted_models[model])
-        return True
-
-    def _validate_auth_decorator(self):
-        # check for the valid auth decorator
-        if self.BRIDGEQL_AUTHENTICATION_DECORATOR:
-            try:
-                load_function(self.BRIDGEQL_AUTHENTICATION_DECORATOR)
-            except (AttributeError, ImportError) as e:
-                raise InvalidBridgeQLSettings(
-                    'Wrong value for settings.BRIDGEQL_AUTHENTICATION_DECORATOR %s'
-                    % self.BRIDGEQL_AUTHENTICATION_DECORATOR
-                )
         return True
 
     def _validate_auth_decorator(self):

--- a/bridgeql/django/views.py
+++ b/bridgeql/django/views.py
@@ -12,6 +12,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 
 from bridgeql import __copyright__, __license__, __title__, __version__
 from bridgeql.django.auth import auth_decorator
+from bridgeql.django.exceptions import InvalidBridgeQLSettings
 from bridgeql.django.schema import BridgeqlModelFields
 from bridgeql.django.models import ModelConfig
 
@@ -31,11 +32,16 @@ def index(request):
 @require_GET
 def generate_bridgeql_schema(request):
     model_info = defaultdict(dict)
-    local_apps_models = BridgeqlModelFields.get_local_apps_models()
+    msg = ""
+    try:
+        local_apps_models = BridgeqlModelFields.get_local_apps_models()
+    except InvalidBridgeQLSettings:
+        msg = "Could not find schema, please initialize BRIDGEQL_ALLOWED_APPS in settings.py"
+        return render(request, "bridgeql/schema.html", {"model_info": dict(model_info), 'msg': msg})
     for app, models in local_apps_models.items():
         model_info[app] = {}
         for model in models:
             _model_config = ModelConfig(app, model)
             _model_name = _model_config.full_model_name
             model_info[app][_model_name] = _model_config.get_fields_attrs()
-    return render(request, "bridgeql/schema.html", {"model_info": dict(model_info)})
+    return render(request, "bridgeql/schema.html", {"model_info": dict(model_info), 'msg': msg})

--- a/bridgeql/templates/bridgeql/schema.html
+++ b/bridgeql/templates/bridgeql/schema.html
@@ -19,8 +19,11 @@
     </title>
   </head>
   <body>
-    <h1>
-    </h1>
+    <h3>
+    {% if msg %}
+    {{ msg }}
+    {% endif %}
+    </h3>
     <table style="width:75%"> 
     <tr>
         <th> App Name </th>

--- a/tests/server/machine/tests/test_settings.py
+++ b/tests/server/machine/tests/test_settings.py
@@ -10,6 +10,7 @@ from bridgeql.django.exceptions import (
     InvalidModelFieldName
 )
 from bridgeql.django.settings import bridgeql_settings
+from bridgeql.django.helpers import get_allowed_apps
 
 
 class TestSettings(TestCase):
@@ -77,4 +78,4 @@ class TestSettings(TestCase):
         self.assertTrue(bridgeql_settings.validate())
 
     def test_list_local_apps(self):
-        self.assertListEqual(bridgeql_settings.get_local_apps(), ['machine'])
+        self.assertListEqual(get_allowed_apps(), ['machine'])

--- a/tests/server/server/settings.py
+++ b/tests/server/server/settings.py
@@ -163,7 +163,7 @@ STATIC_URL = '/static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-BRIDGEQL_ALLOWED_APPS = []
+#BRIDGEQL_ALLOWED_APPS = []
 BRIDGEQL_RESTRICTED_MODELS = {
     'auth.User': True,
     'machine.OperatingSystem': ['license_key'],

--- a/tests/server/server/settings.py
+++ b/tests/server/server/settings.py
@@ -18,6 +18,7 @@ import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+SITE_ROOT = BASE_DIR
 
 
 # Quick-start development settings - unsuitable for production
@@ -130,6 +131,7 @@ STATIC_URL = '/static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
+BRIDGEQL_ALLOWED_APPS = []
 BRIDGEQL_RESTRICTED_MODELS = {
     'auth.User': True,
     'machine.OperatingSystem': ['license_key'],


### PR DESCRIPTION
To see the schema of project, user need to define BRIDGEQL_ALLOWED_APPS in settings.py. If this settings is not defined then all the local apps (app created by user) will be in the allowed apps list. User must define either BASE_DIR or SITE_ROOT or BRIDGEQL_ALLOWED_APPS. In nothing is defined, then a message will be displayed in schema page to initilize BRIDGEQL_ALLOWED_APPS