### PR TITLE
delegate handling of foreign key references to values function of queryset

### DIFF
--- a/bridgeql/__init__.py
+++ b/bridgeql/__init__.py
@@ -14,7 +14,7 @@
 """
 
 __title__ = 'BridgeQL'
-__version__ = '0.1.14'
+__version__ = '0.1.15'
 __license__ = 'BSD 2-Clause'
 __copyright__ = 'Copyright © 2023 VMware, Inc.  All rights reserved.'
 

--- a/bridgeql/django/fields.py
+++ b/bridgeql/django/fields.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2023 VMware, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+
+class Field(object):
+    def __init__(self, model_config, field_name):
+        self.model_config = model_config
+        self.name = field_name
+        self._resolve_pk()
+
+    def _resolve_pk(self):
+        if self.name == 'pk':
+            self.name = self.model_config.model._meta.pk.name
+
+    @property
+    def is_restricted(self):
+        return self.name in self.model_config.restricted_fields
+
+
+class FieldAttributes(object):
+
+    def __init__(self, name, is_null, field_type, help_text):
+        self.field_name = name
+        self.is_null = is_null
+        self.field_type = field_type
+        self.help_text = help_text

--- a/bridgeql/django/model_meta.py
+++ b/bridgeql/django/model_meta.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2023 VMware, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Everything related to model._meta
+"""
+
+
+def _get_fields(model):
+    return set([f.name for f in model._meta.local_fields])
+
+
+def get_properties(model):
+    return set(model._meta._property_names) - {'pk'}

--- a/bridgeql/django/models.py
+++ b/bridgeql/django/models.py
@@ -16,7 +16,8 @@ from bridgeql.django.exceptions import (
     InvalidModelFieldName,
     InvalidQueryException,
 )
-from bridgeql.django.query import construct_query, extract_keys
+from bridgeql.django.fields import Field, FieldAttributes
+from bridgeql.django.query import Query
 from bridgeql.django.settings import bridgeql_settings
 
 
@@ -45,30 +46,6 @@ class Parameters(object):
         # validation for required fields
         if not any((self.app_name, self.model_name)):
             raise InvalidRequest('app_name or model_name missing')
-
-
-class Field(object):
-    def __init__(self, model_config, field_name):
-        self.model_config = model_config
-        self.name = field_name
-        self._resolve_pk()
-
-    def _resolve_pk(self):
-        if self.name == 'pk':
-            self.name = self.model_config.model._meta.pk.name
-
-    @property
-    def is_restricted(self):
-        return self.name in self.model_config.restricted_fields
-
-
-class FieldAttributes(object):
-
-    def __init__(self, name, is_null, field_type, help_text):
-        self.field_name = name
-        self.is_null = is_null
-        self.field_type = field_type
-        self.help_text = help_text
 
 
 class ModelConfig(object):
@@ -171,8 +148,8 @@ class ModelBuilder(object):
         self.model_config = ModelConfig(
             self.params.app_name, self.params.model_name)
         requested_fields = list()
-        requested_fields.extend(extract_keys(self.params.filter))
-        requested_fields.extend(extract_keys(self.params.exclude))
+        requested_fields.extend(Query.extract_keys(self.params.filter))
+        requested_fields.extend(Query.extract_keys(self.params.exclude))
         requested_fields.extend(self.params.fields)
         requested_fields.extend(self.params.order_by)
         self.model_config.validate_fields(set(requested_fields))
@@ -251,12 +228,12 @@ class ModelBuilder(object):
 
     def queryset(self):
         # construct Q object from dictionary
-        query = construct_query(self.params.filter)
+        query = Query(self.params.filter)
         if self.params.db_name:
             self.qset = self.model_config.model.objects.using(
-                self.params.db_name).filter(query)
+                self.params.db_name).filter(query.Q)
         else:
-            self.qset = self.model_config.model.objects.filter(query)
+            self.qset = self.model_config.model.objects.filter(query.Q)
         self._apply_opts()
         if isinstance(self.qset, QuerySet):
             logger.debug('Request parameters: %s \nQuery: %s\n',

--- a/bridgeql/django/query.py
+++ b/bridgeql/django/query.py
@@ -7,47 +7,36 @@ from django.db.models import Q
 from bridgeql.django.exceptions import InvalidQueryException
 
 
-def construct_query(selector):
-    """
-    selector: {
-        'pk': 123,
-        'type': 'release',
-        '__or': [
-            {'user': args.user},
-            {'email': args.email}
-        ]
-    }
+class Query(object):
 
-    selector: {
-        '__or': [
-            {'pk': 1, 'user': 'John Doe'},
-            {'buildtype': 'release'}
-        ]
-    }
-    """
-    query = Q()
-    if selector is None:
-        return query
-    if not isinstance(selector, dict):
-        raise InvalidQueryException(
-            "Selector is of the type %s, expected dict" % type(selector))
-    or_filter = selector.pop('__or', [])
-    if or_filter:
-        if not isinstance(or_filter, list):
+    def __init__(self, query_dict):
+        self.query_dict = query_dict
+        self.Q = self.construct_query(self.query_dict)
+
+    def construct_query(self, query_dict):
+        query = Q()
+        if query_dict is None:
+            return query
+        if not isinstance(query_dict, dict):
             raise InvalidQueryException(
-                "__or filter is of the type %s, expected list" % type(or_filter))
-        for f in or_filter:
-            query.add(construct_query(f), conn_type=Q.OR)
-    return query & Q(**dict(selector))
+                "Selector is of the type %s, expected dict" % type(query_dict))
+        or_filter = query_dict.pop('__or', [])
+        if or_filter:
+            if not isinstance(or_filter, list):
+                raise InvalidQueryException(
+                    "__or filter is of the type %s, expected list" % type(or_filter))
+            for f in or_filter:
+                query.add(self.construct_query(f), conn_type=Q.OR)
+        return query & Q(**dict(query_dict))
 
-
-def extract_keys(query_dict):
-    exclusion = ('__or',)
-    keys = []
-    for key, val in query_dict.items():
-        if key not in exclusion:
-            keys.append(key)
-        else:
-            for nested_dict in val:
-                keys.extend(extract_keys(nested_dict))
-    return keys
+    @classmethod
+    def extract_keys(cls, query_dict):
+        exclusion = ('__or',)
+        keys = []
+        for key, val in query_dict.items():
+            if key not in exclusion:
+                keys.append(key)
+            else:
+                for nested_dict in val:
+                    keys.extend(Query.extract_keys(nested_dict))
+        return keys

--- a/bridgeql/django/urls.py
+++ b/bridgeql/django/urls.py
@@ -14,7 +14,7 @@ from bridgeql.django.views import index, generate_bridgeql_schema
 bridgeql_settings.validate()
 
 urlpatterns = [
-    path('dj_read/', read_django_model, name='bridgeql_django_read'),
+    path('reader/', read_django_model, name='bridgeql_django_read'),
     path('schema/', generate_bridgeql_schema, name='generate_bridgeql_schema'),
     path('', index, name='bridgeql_django_index'),
 ]

--- a/bridgeql/types.py
+++ b/bridgeql/types.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2023 VMware, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
 class DBRows(list):
     # override count method of list
     def count(self):

--- a/bridgeql/types.py
+++ b/bridgeql/types.py
@@ -1,0 +1,4 @@
+class DBRows(list):
+    # override count method of list
+    def count(self):
+        return len(self)

--- a/tests/server/machine/tests/test_api_reader.py
+++ b/tests/server/machine/tests/test_api_reader.py
@@ -32,6 +32,7 @@ class TestAPIReader(TestCase):
         resp = self.client.get(self.url, {'payload': json.dumps(self.params)})
         self.assertEqual(resp.status_code, 200)
         resp_json = resp.json()
+        print(resp_json)
         self.assertEqual(resp_json['data'][0]['ip'], "10.0.0.1")
 
     def test_get_os(self):
@@ -47,6 +48,32 @@ class TestAPIReader(TestCase):
         self.assertEqual(resp.status_code, 200)
         resp_json = resp.json()
         self.assertEqual(resp_json['data'][0]['arch'], "arch-name-1")
+
+    def test_get_only_property(self):
+        self.params = {
+            'app_name': 'machine',
+            'model_name': 'Machine',
+            'filter': {
+                'name': 'machine-name-1'
+            },
+            'fields': ['stats']
+        }
+        resp = self.client.get(self.url, {'payload': json.dumps(self.params)})
+        self.assertEqual(resp.status_code, 200)
+        resp_json = resp.json()
+        print(resp_json)
+        self.assertEqual(resp_json['data'][0]['stats'], "CPU: 2, Mem 1GB")
+
+    def test_empty_fields(self):
+        self.params = {
+            'app_name': 'machine',
+            'model_name': 'Machine',
+            'filter': {
+                'name': 'machine-name-1'
+            }
+        }
+        resp = self.client.get(self.url, {'payload': json.dumps(self.params)})
+        self.assertEqual(resp.status_code, 200)
 
     def test_or_query(self):
         self.params = {


### PR DESCRIPTION
Previously we were handling foreign key references manually by iterating through the whole `queryset` if properties are present. This proved to be inefficient if the number of records are **large enough** say 40k. Without pagination this was causing gateway timeout errors. This change includes separating the parameters which should be passed to `values` function of the queryset (includes foreign key references) and fetch the model properties by iterating through the queryset.