### PR TITLE
add logging in case of unsuccessful operation

### DIFF
--- a/bridgeql/django/bridge.py
+++ b/bridgeql/django/bridge.py
@@ -5,7 +5,7 @@
 import json
 from django.views.decorators.http import require_GET
 
-
+from bridgeql.django import logger
 from bridgeql.django.auth import auth_decorator
 from bridgeql.django.exceptions import (
     ForbiddenModelOrField,
@@ -28,11 +28,14 @@ def read_django_model(request):
         res = {'data': qset, 'message': '', 'success': True}
         return JSONResponse(res)
     except ForbiddenModelOrField as e:
+        logger.error(e)
         res = {'data': [], 'message': str(e), 'success': False}
         return JSONResponse(res, status=403)
     except InvalidRequest as e:
+        logger.error(e)
         res = {'data': [], 'message': str(e), 'success': False}
         return JSONResponse(res, status=400)
     except Exception as e:
+        logger.exception(e)
         res = {'data': [], 'message': str(e), 'success': False}
         return JSONResponse(res, status=500)


### PR DESCRIPTION
display complete traceback if there is an Internal server error (for status code 500) otherwise log the error statement only.