### PR TITLE
add db_name to create, update, delete urls

### DIFF
--- a/bridgeql/django/urls.py
+++ b/bridgeql/django/urls.py
@@ -14,11 +14,13 @@ from bridgeql.django.views import index, generate_bridgeql_schema
 bridgeql_settings.validate()
 
 urlpatterns = [
+    path('create/(?P<db_name>\w+)/(?P<app_label>\w+)/(?P<model_name>\w+)/',
+         bridge.create_django_model, name='bridgeql_django_create'),
     path('read/', bridge.read_django_model, name='bridgeql_django_read'),
-    path('update/(?P<app_label>\w+)/(?P<model_name>\w+)/(?P<pk>\w+)/',
-         bridge.write_django_model, name='bridgeql_django_update'),
-    path('create/(?P<app_label>\w+)/(?P<model_name>\w+)/',
-         bridge.write_django_model, name='bridgeql_django_create'),
+    path('update/(?P<db_name>\w+)/(?P<app_label>\w+)/(?P<model_name>\w+)/(?P<pk>\w+)/',
+         bridge.update_django_model, name='bridgeql_django_update'),
+    path('delete/(?P<db_name>\w+)/(?P<app_label>\w+)/(?P<model_name>\w+)/(?P<pk>\w+)/',
+         bridge.delete_django_model, name='bridgeql_django_delete'),
     path('schema/', generate_bridgeql_schema, name='generate_bridgeql_schema'),
     path('', index, name='bridgeql_django_index'),
 ]

--- a/tests/server/machine/tests/test_api_reader.py
+++ b/tests/server/machine/tests/test_api_reader.py
@@ -407,7 +407,8 @@ class TestAPIReader(TestCase):
         self.assertEqual(resp.status_code, 400)
         resp_json = resp.json()
         self.assertFalse(resp_json['success'])
-        self.assertEqual('Invalid aggregate function Mix', resp_json['message'])
+        self.assertEqual('Invalid aggregate function Mix',
+                         resp_json['message'])
 
     @override_settings(BRIDGEQL_AUTHENTICATION_DECORATOR='server.auth.localtest')
     def test_custom_auth_decorator(self):


### PR DESCRIPTION
User is required to pass db_name explicitly in url. This will make sure that we are connecting to the right database.
Added delete operation which will delete the model object based on the primary key passed in the url.

Added test cases for delete and invalid db connection