### PR TITLE
skip restricted fields from display when object is retrieved via pk

### DIFF
--- a/bridgeql/django/models.py
+++ b/bridgeql/django/models.py
@@ -238,10 +238,11 @@ class ModelBuilder(object):
             # offset and limit operation will return None
             func = getattr(self.qset, qset_opt, None)
             value = getattr(self.params, opt, None)
-            # do not execute operation if value is not passed,
+            # do not execute operation (except values)
+            # if value is not passed,
             # or it does not have default value specified in
             # Parameters class such as [], {}, False
-            if value is None:
+            if not value and qset_opt != 'values':
                 continue
             if not isinstance(value, opt_type):
                 raise InvalidQueryException('Invalid type %s for %s'
@@ -272,6 +273,11 @@ class ModelBuilder(object):
                     # returns DBRows instance
                     self.qset = self._add_fields()
                 else:
+                    # in case if fields is not present in the query
+                    # return all fields but restricted
+                    if not value:
+                        value = list(
+                            self.model_config.fields - self.model_config.restricted_fields)
                     try:
                         self.qset = func(*value)
                     except FieldError as e:

--- a/tests/server/machine/tests/test_api_reader.py
+++ b/tests/server/machine/tests/test_api_reader.py
@@ -145,7 +145,6 @@ class TestAPIReader(TestCase):
             self.getURL(), {'payload': json.dumps(self.params)})
         self.assertEqual(resp.status_code, 200)
         res_json = resp.json()
-        # self.assertEqual(10, res_json['data'])
         self.assertEqual(10, len(res_json['data']))
 
     def test_count_query(self):

--- a/tests/server/machine/tests/test_api_reader.py
+++ b/tests/server/machine/tests/test_api_reader.py
@@ -56,11 +56,12 @@ class TestAPIReader(TestCase):
         assert _checkListEqual(
             list(resp_json['data'][0].keys()), self.params['fields'])
 
-    def test_get_machine_by_pk(self):
-        resp = self.client.get(self.getURL(pk=1))
+    def test_get_os_by_pk(self):
+        resp = self.client.get(self.getURL(pk=1, model_name='OperatingSystem'))
         self.assertEqual(resp.status_code, 200)
         resp_json = resp.json()
         self.assertEqual(resp_json['data'][0]['id'], 1)
+        self.assertNotIn('license_key', resp_json['data'][0])
 
     def test_get_os(self):
         self.params = {
@@ -144,6 +145,7 @@ class TestAPIReader(TestCase):
             self.getURL(), {'payload': json.dumps(self.params)})
         self.assertEqual(resp.status_code, 200)
         res_json = resp.json()
+        # self.assertEqual(10, res_json['data'])
         self.assertEqual(10, len(res_json['data']))
 
     def test_count_query(self):


### PR DESCRIPTION
 If user makes an API call to the url which gets the single model instance based on the pk passed in the url, then fields restricted are not displayed. This is also valid is fields operaion is not present in the query.
    
Added test case
