### PR TITLE
add stream API

### DIFF
--- a/bridgeql/django/bridge.py
+++ b/bridgeql/django/bridge.py
@@ -3,14 +3,19 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import json
+import time
 
+from django.http import StreamingHttpResponse
+from django.utils.decorators import method_decorator
 from django.views.decorators.http import require_http_methods
 from django.views.decorators.csrf import csrf_exempt
+from django.views import View
 
 from bridgeql.django.auth import read_auth_decorator, write_auth_decorator
 from bridgeql.django.exceptions import BridgeqlException
 from bridgeql.django.helpers import JSONResponse, get_json_request_body
 from bridgeql.django.models import ModelBuilder, ModelObject
+from bridgeql.django.query import Query
 
 
 @csrf_exempt
@@ -32,6 +37,31 @@ def create_django_model(request, db_name, app_label, model_name):
         res = {'data': [], 'message': str(e.detail), 'success': False}
         return JSONResponse(res, status=e.status_code)
 
+
+@method_decorator(require_http_methods(['GET']), name='dispatch')
+class StreamView(View):
+
+    def stream_response(self, mb, chunk_size):
+        for i, x in enumerate(mb.queryset(stream=True)):
+            yield x
+            if i % chunk_size == 0:
+                time.sleep(1)
+
+    def get(self, request, db_name, app_label, model_name):
+        chunk_size = request.GET.get('chunk_size', 1000)
+        try:
+            chunk_size = int(chunk_size)
+        except ValueError:
+            chunk_size = 1000
+        params = request.GET.get('payload', None)
+        try:
+            params = json.loads(params)
+            mb = ModelBuilder(db_name, app_label, model_name, params)
+            return StreamingHttpResponse(self.stream_response(mb, chunk_size), content_type='application/json')
+        except BridgeqlException as e:
+            e.log()
+            res = {'data': [], 'message': str(e.detail), 'success': False}
+            return JSONResponse(res, status=e.status_code)
 
 @require_http_methods(['GET'])
 @read_auth_decorator

--- a/bridgeql/django/urls.py
+++ b/bridgeql/django/urls.py
@@ -15,6 +15,8 @@ bridgeql_settings.validate()
 urlpatterns = [
     url(r'^create/(?P<db_name>\w+)/(?P<app_label>\w+)/(?P<model_name>\w+)/$',
          bridge.create_django_model, name='bridgeql_django_create'),
+    url(r'^stream/(?P<db_name>\w+)/(?P<app_label>\w+)/(?P<model_name>\w+)/$',
+         bridge.StreamView.as_view(), name='bridgeql_django_stream'),
     url(r'^read/(?P<db_name>\w+)/(?P<app_label>\w+)/(?P<model_name>\w+)/(?P<pk>\w+)/$',
          bridge.read_django_model, name='bridgeql_django_read_pk'),
     url(r'^read/(?P<db_name>\w+)/(?P<app_label>\w+)/(?P<model_name>\w+)/$',

--- a/tests/server/machine/tests/test_api_streamer.py
+++ b/tests/server/machine/tests/test_api_streamer.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+# Copyright © 2023 VMware, Inc.  All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause
+
+import json
+import os
+
+from django.urls import reverse as url_reverse
+from django.test import TestCase, override_settings
+from django.test.client import Client
+from django.conf import settings
+
+from machine.models import OperatingSystem, Machine
+
+
+class TestAPIStreamer(TestCase):
+    fixtures = [os.path.join(settings.BASE_DIR, 'machine_tests.json'), ]
+
+    def setUp(self):
+        self.client = Client()
+
+    def getURL(self, **kwargs):
+        db_name = kwargs.get('db_name', 'default')
+        app_label = kwargs.get('app_label', 'machine')
+        # default model name is Machine
+        model_name = kwargs.get('model_name', 'Machine')
+        url_name = 'bridgeql_django_stream'
+        url_kwargs = {
+            'db_name': db_name,
+            'app_label': app_label,
+            'model_name': model_name
+        }
+        return url_reverse(url_name, kwargs=url_kwargs)
+
+    # add properties
+    def test_stream_one_field(self):
+        self.params = {
+            'filter': {
+                'name__startswith': 'machine',
+            },
+            'fields': ['os__name', 'pk']
+        }
+        resp = self.client.get(
+            self.getURL(), {'payload': json.dumps(self.params), 'chunk_size':50})
+        if resp.status_code == 200:
+            streaming_content = []
+            for chunk in resp.streaming_content:
+                streaming_content.append(chunk)
+            self.assertEqual(len(streaming_content), 100)
+
+    def test_stream_invalid_model_name(self):
+        self.params = {
+            'filter': {
+                'name__startswith': 'os-name-',
+            },
+            'fields': ['name', 'arch'],
+        }
+        resp = self.client.get(self.getURL(model_name='InvalidModel'), {
+                               'payload': json.dumps(self.params)})
+        self.assertEqual(resp.status_code, 400)
+        self.assertFalse(resp.json()['success'])


### PR DESCRIPTION
Add stream API to stream data for a large number of results, this can be controlled by chunk_size query parameter, the server will sleep for 1 second when it has yieled `chunk_size` data. The server needs to sleep for 1 second since it needs time to gather the records (chunk_size).